### PR TITLE
Fixes #330 file is undefined error after page reload

### DIFF
--- a/components/editor/init.js
+++ b/components/editor/init.js
@@ -78,7 +78,7 @@
 			// Prompt if a user tries to close window without saving all files
 			window.onbeforeunload = function(e) {
 				let changedPaths = self.getChangedPaths();
-				if (changedPaths) {
+				if (changedPaths.length) {
 					self.focusOnFile(changedPaths[0]);
 					e = e || window.event;
 					var errMsg = 'You have unsaved files.';


### PR DESCRIPTION
This pull request fixes Atheos/Atheos#330

The [getChangedPaths](https://github.com/Atheos/Atheos/blob/552d86070f5ba723c99b2f3f030527a0b077b17d/components/editor/init.js#L430) function returns an array so the truthy check should be replaced with an array length check.
The only way the function returns falsy are if an exception occurs before the return (ReferenceError/TypeError).