### PR TITLE
Corrected object context for openFile method to avoid an error on file creation

### DIFF
--- a/components/filetree/init.js
+++ b/components/filetree/init.js
@@ -706,7 +706,7 @@
 					// Add new element to file tree
 					self.addToFileTree(path, type, self.activeAnchor.path, 0);
 					if (type === 'file') {
-						self.openFile(path, true);
+						atheos.editor.openFile(path, true);
 					}
 					/* Notify listeners. */
 					carbon.publish('filetree.create', {


### PR DESCRIPTION
**Describe the bug**
Creating a new file in a project causes an error in version 608.
The following error messages appears in the browser console:

```
Uncaught TypeError: self.openFile is not a function
    settled https://mypage/Atheos608/components/filetree/init.js:709
    onreadystatechange https://mypage/Atheos608/libraries/echo.js:72
    echo https://mypage/Atheos608/libraries/echo.js:50
    create https://mypage/Atheos608/components/filetree/init.js:695
    eventHandler https://mypage/Atheos608/libraries/flux.js:52
    eventHandler https://mypage/Atheos608/libraries/flux.js:48
    on https://mypage/Atheos608/libraries/flux.js:98
    on https://mypage/Atheos608/libraries/flux.js:94
    on https://mypage/Atheos608/libraries/flux.js:162
    init https://mypage/Atheos608/components/filetree/init.js:42
    <anonymous> https://mypage/Atheos608/components/filetree/init.js:923
    pub https://mypage/Atheos608/libraries/carbon.js:50
    restoreState https://mypage/Atheos608/modules/system.js:80
    init https://mypage/Atheos608/modules/system.js:52
    on https://mypage/Atheos608/libraries/flux.js:98
    forEach self-hosted:157
    on https://mypage/Atheos608/libraries/flux.js:94
    on https://mypage/Atheos608/libraries/flux.js:162
    init https://mypage/Atheos608/components/filetree/init.js:42
    <anonym> https://mypage/Atheos608/components/filetree/init.js:923
    pub https://mypage/Atheos608/libraries/carbon.js:50
    restoreState https://mypage/Atheos608/modules/system.js:80
    init https://mypage/Atheos608/modules/system.js:52
```
The file was created and editing an saving is possible.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to any project. 
2. Right click on a folder than chose create file from the menu.
3. See the error in the browser console.

**Expected behavior**
No error should appear in console.

**Additional info**
The error occurs also with the changes from the development branch.
The openFile method was removed from `components/filetree/init.js` (previously called `components/filemanager/init.js`) in this commit: https://github.com/Atheos/Atheos/commit/43ffd25ac9d227c85919adf8b8d7d8ff51fde42a