### PR TITLE
Make autosaving a file in a draft work again

### DIFF
--- a/components/draft/class.draft.php
+++ b/components/draft/class.draft.php
@@ -55,8 +55,7 @@ class Draft {
 			Common::send(104, "draft_none");
 		}
 
-		$name = $results[0]["name"];
-		Common::deleteCache($name, "drafts");
+		Common::deleteCache($path . $this->activeUser, "drafts");
 		$this->db->delete($where);
 		Common::send(200);
 	}
@@ -71,15 +70,14 @@ class Draft {
 			Common::send(104, "draft_none");
 		}
 
-		$name = $results[0]["name"];
-		$content = Common::loadCache($name, "drafts");
+		$content = Common::loadCache($path . $this->activeUser, "drafts");
 
 		if (!$content) {
-			$this->db->delete($where);
 			Common::send(404, "Draft file missing.");
 		}
 
-		Common::deleteCache($name, "drafts");
+		Common::deleteCache($path . $this->activeUser, "drafts");
+		$this->db->delete($where);
 		Common::send(200, array("content" => $content));
 	}
 

--- a/components/draft/init.js
+++ b/components/draft/init.js
@@ -51,13 +51,13 @@
 		autosave: function() {
 			if (!self.enabled || self.saving.length > 0) return;
 
-			var changedPaths = atheos.editor.getChangedPaths();
+			let changedPaths = atheos.editor.getChangedPaths();
 			if (!changedPaths.length) return;
 
 			changedPaths.forEach(function(path) {
-				let session = atheos.editor.sessions[path];
-				if (session.autosaved) return;
-				self.save(session);
+				let file = atheos.editor.getFile(path);
+				if (file.autosaved) return;
+				self.save(file);
 			});
 		},
 
@@ -101,9 +101,9 @@
 		},
 
 		open: function(path) {
-			let session = atheos.editor.sessions[path];
+			let file = atheos.editor.getFile(path);
 			
-			if(!session) return;
+			if(!file) return;
 
 			echo({
 				data: {
@@ -113,30 +113,32 @@
 				},
 				settled: function(reply, status) {
 					if (status !== 200) return;
-					session.setValue(reply.content, 1);
+					file.aceSession.setValue(reply.content, 1);
+					atheos.editor.markChanged(path);
+					atheos.editor.focusOnFile(path);
 				}
 			});
 		},
 
-		save: function(session) {
-			self.saving.push[session.path];
+		save: function(file) {
+			self.saving.push[file.path];
 
-			let content = session.getValue();
+			let content = file.aceSession.getValue();
 
 			echo({
 				data: {
 					target: 'draft',
 					action: 'save',
-					path: session.path,
+					path: file.path,
 					content
 				},
 				settled: function(reply, status) {
 					if (status !== 200) return;
 
 
-					let index = self.saving.indexOf(session.path);
+					let index = self.saving.indexOf(file.path);
 					self.saving = self.saving.splice(index, 1);
-					session.autosaved = true;
+					file.autosaved = true;
 
 					if (self.verbose && self.saving.length === 0) {
 						atheos.toast.show('success', 'Autosave to draft complete.');

--- a/traits/file.php
+++ b/traits/file.php
@@ -99,17 +99,25 @@ trait File {
     }
 
     //////////////////////////////////////////////////////////////////////////80
-    // Delete file within data
+    // Delete file within DATA
     //////////////////////////////////////////////////////////////////////////80
     public static function delete($name, $namespace) {
         $path = DATA . "/" . $namespace . "/" . $name;
         $path = preg_replace("#\/+#", "/", $path);
+
         if (is_file($path)) {
             unlink($path);
             return true;
-        } else {
-            return false;
         }
+
+        // Next try the new PHP-wrapped format.
+        $wrapped = $path . ".php";
+        if (is_file($wrapped)) {
+            unlink($wrapped);
+            return true;
+        }
+
+        return false;
     }
 
     //////////////////////////////////////////////////////////////////////////80


### PR DESCRIPTION
**Describe the bug**
The autosave in a draft function did not work in version 608.
The following error messages appears in the browser console:

```
Uncaught TypeError: can't access property "/Atheos608/traits/database.php", atheos.editor.sessions is undefined
    autosave https://mypage/Atheos608/components/draft/init.js:58
    autosave https://mypage/Atheos608/components/draft/init.js:57
    defer https://mypage/Atheos608/libraries/global.js:66
    setTimeout handler*window.throttle/< https://mypage/Atheos608/libraries/global.js:64
    pub https://mypage/Atheos608/libraries/carbon.js:50
    kilo https://mypage/Atheos608/modules/chrono.js:51
    setInterval handler* https://mypage/Atheos608/modules/chrono.js:51
    <anonymous> https://mypage/Atheos608/modules/chrono.js:57
    autosave https://mypage/Atheos608/components/draft/init.js:58
    forEach self-hosted:157
    autosave https://mypage/Atheos608/components/draft/init.js:57
    defer https://mypage/Atheos608/libraries/global.js:66
    (Async: setTimeout handler)
    throttle https://mypage/Atheos608/libraries/global.js:64
    pub https://mypage/Atheos608/libraries/carbon.js:50
    kilo https://mypage/Atheos608/modules/chrono.js:51
    (Async: setInterval handler)
    <anonym> https://mypage/Atheos608/modules/chrono.js:51
    <anonym> https://mypage/Atheos608/modules/chrono.js:57
```

**To Reproduce**
Steps to reproduce the behavior:
1. Go to any project.
2. Open a file and change something.
3. Wait until the autosave draft time is up.
4. See se error in the browser console.

**Expected behavior**
No error should appear in console and a draft should be saved and loaded again.

**Desktop (please complete the following information):**
 - OS: Linux
 - Browser: Firefox 147.0.3

This pull request adjusts the files so that everything works with the last major changes.
- `session` was replaced with `file.aceSession`
- `Common::loadCache` was changed to `Common::load` because `$name` is already hashed, same for `Common::deleteCache`. 
-  Additions for new PHP-wrapped format