### PR TITLE
Corrected method name in logout function and renewed discard changes function

### DIFF
--- a/components/user/init.js
+++ b/components/user/init.js
@@ -356,7 +356,7 @@
 
 			let changedPaths = atheos.editor.getChangedPaths();
 			if (changedPaths.length) {
-				atheos.editor.focus(changedPaths[0]);
+				atheos.editor.focusOnFile(changedPaths[0]);
 				let changes = '';
 				changedPaths.forEach(function(path, i) {
 					changes += pathinfo(path).basename + '\n';
@@ -371,9 +371,9 @@
 							postLogout();
 						},
 						'Discard Changes': function() {
-							for (let path in atheos.editor.sessions) {
-								atheos.editor.sessions[path].status = 'current';
-							}
+							changedPaths.forEach(function(path) {
+								atheos.editor.activeFiles[path].status = 'current';
+							});
 							postLogout();
 						},
 						'Cancel': function() {


### PR DESCRIPTION
**Describe the bug**

Logout dialog does not open if a active file is unsaved with changes.
The following error messages appears in the browser console:

```
Uncaught TypeError: atheos.editor.focus is not a function
    logout https://mypage/Atheos608/components/user/init.js:359
    onclick https://mypage/Atheos608/:1
    logout https://mypage/Atheos608/components/user/init.js:359
    onclick https://mypage/Atheos608/:1
```

**To Reproduce**
Steps to reproduce the behavior:
1. Go to any project. 
2. Open a files and change something.
3. Try to logout.

**Expected behavior**
Logout dialog should appear.

**Desktop (please complete the following information):**
 - OS: Linux
 - Browser: Firefox 147.0.4

**Additional info**
Tested with the latest changes from the development branch.

**This pull request:**
- Changes atheos.editor.focus to atheos.editor.focusOnFile so no error appears and the logout dialog is displayed.
- The discard changes function was changed to work with the latest major changes of Atheos.

