### PR TITLE
Avoids an exception on first login loadState call

### DIFF
--- a/traits/database.php
+++ b/traits/database.php
@@ -31,7 +31,7 @@ class Store {
     protected $data = array();
 
     function __construct($table, $path) {
-        if (!is_dir($path)) mkdir($path);
+        if (!is_dir($path)) mkdir($path, 0755, true);
 
         $this->path = $path . $table . ".db.php";
         if (is_readable($this->path)) {


### PR DESCRIPTION
**Describe the bug**

After the insattllation process of Atheos it is not possible to open any file.

Internal server error: 
```
https://myAtheos/controller.php [HTTP/2 500  109ms]	
target	"editor"
action	"openFile"
path	"/to/myfile.txt"
inFocus	"true" 
```

**To Reproduce**
Steps to reproduce the behavior:
1. Install Atheos.
2. After the install process try to open some file.
3. See the error in the browser console.

**Expected behavior**
Files should open without logout and login again after installation (than the error was gone).

**Desktop (please complete the following information):**
 - OS: Linux
 - Browser: Firefox 147.0.4

**Reason**

https://github.com/Atheos/Atheos/blob/668dddf575893e9a9c2e1ee20b557452463d76ee/traits/database.php#L34

throws an `mkdir(): No such file or directory` exception if `$table` is `activeFiles` and `$path` is `/path/to/myAtheos/data/users/myuser/` because the folder `data/users` does not exists at first login after install.

**Additional info**
To debug the exception add an try catch block to the `loadState` method of the `Common` class and look into
the `$e->getMessage()` and the `$e->getTrace()` results.

Tested with the latest changes from the development branch.
PHP version 8.5

**This pull request**
Resolves the problem by adding parameters for recursive folder creation.