### PR TITLE
Prevents an unintended file or folder move and an error on drag end in the filetree

### DIFF
--- a/components/filetree/init.js
+++ b/components/filetree/init.js
@@ -156,13 +156,15 @@
 			// & https://github.com/io-developer/js-dragndrop
 			e.stopPropagation();
 
-			var target = e.target;
-			var origin, sibling;
+			let target = e.target;
+			let origin, sibling;
 
-			var dragZone = oX('#FILETREE').element;
-			var clone, startEX, startEY, startMX, startMY, timeout;
+			let dragZone = oX('#FILETREE').element;
+			let clone, startEX, startEY, startMX, startMY, timeout;
 
-			var xMax, yMax;
+			let xMax, yMax;
+
+			let swapCount = 0;
 
 			// Move actual/invisible node around / ID target
 
@@ -171,10 +173,10 @@
 			function moveTarget(e) {
 				timeout = false;
 
-				var swap = [].slice.call(dragZone.querySelectorAll('.draggable'));
+				let swap = [].slice.call(dragZone.querySelectorAll('.draggable'));
 
 				swap = swap.filter((item) => {
-					var rect = item.getBoundingClientRect();
+					let rect = item.getBoundingClientRect();
 					if (e.clientX < rect.left || e.clientX >= rect.right) return false;
 					if (e.clientY < rect.top || e.clientY >= rect.bottom) return false;
 					return (item !== clone);
@@ -190,7 +192,8 @@
 							iNode.classList.replace('fa-download', 'fa-folder');
 						});
 						swap.parentNode.insertBefore(target, swap.nextSibling);
-						if (swap.querySelectorAll('a[data-type="folder"],a[data-type="root"]').length > 0) {
+						swapCount = swap.querySelectorAll('a[data-type="folder"],a[data-type="root"]').length;
+						if (swapCount) {
 							swap.querySelector('i[data-type="folder"],i[data-type="root"]').classList.replace('fa-folder', 'fa-download');
 						}
 					}
@@ -199,7 +202,7 @@
 
 			// Move clone/ghost element node
 			function dragMove(e) {
-				var x = startEX + e.screenX - startMX,
+				let x = startEX + e.screenX - startMX,
 					y = startEY + e.screenY - startMY;
 
 				// Clamp / wrap coordinates
@@ -253,14 +256,15 @@
 				target.style.opacity = '';
 				if (clone) clone.remove();
 
-				var parentUl = target.closest('ul');
-				var parentFolder = target.previousSibling.querySelector('a[data-type="folder"],a[data-type="root"]');
-				var folder;
+				let parentFolder = target.previousSibling?.querySelector('a[data-type="folder"],a[data-type="root"]'),
+					parentUl = target.closest('ul'),
+					folder;
 				if (!parentFolder) {
 					if (!parentUl) return;
 					folder = parentUl.previousElementSibling;
 					if (parentUl === origin || !folder) return origin.append(target);
 				} else {
+					if (!swapCount) return origin.append(target); // Prevents unintended move of draggable
 					dragZone.querySelectorAll('i[data-type="folder"],i[data-type="root"]').forEach(function(iNode) {
 						iNode.classList.replace('fa-download', 'fa-folder');
 					});


### PR DESCRIPTION
**Describe the bugs**

1. Drag and drop of the first file/folder back to his start position causes an unintendet file/folder move if there is a folder above the file/folder (a subolder of the rootfolder). 

    ![Filtree_drag_file1](https://github.com/user-attachments/assets/39c5d138-47f5-495c-af1c-eaabe39e930c)
After mouse up the file `testx4.txt `was moved into `sub1` without selecting this folder as destination.  This could be confusing.

2. Drag and drop of the first file/folder back to his start position causes an error:
```
Uncaught TypeError: can't access property "querySelector", target.previousSibling is null
    dragEnd https://myAtheos/components/filetree/init.js:257
    handleDrag https://myAtheos/components/filetree/init.js:279
    eventHandler https://myAtheos/libraries/flux.js:52
    eventHandler https://myAtheos/libraries/flux.js:48
    on https://myAtheos/libraries/flux.js:98
    on https://myAtheos/libraries/flux.js:94
    on https://myAtheos/libraries/flux.js:162
    nodeListener https://myAtheos/components/filetree/init.js:149
    init https://myAtheos/components/filetree/init.js:26
    <anonymous> https://myAtheos/components/filetree/init.js:923
    pub https://myAtheos/libraries/carbon.js:50
    restoreState https://myAtheos/modules/system.js:80
    init https://myAtheos/modules/system.js:52
    EventListener.handleEvent* https://myAtheos/modules/system.js:117
    <anonymous> https://myAtheos/modules/system.js:119
```

**To Reproduce**
Steps to reproduce the behavior for bug 1:
1. Open a project with a sub folder and drag the first file/folder below this folder.
2. Let the file/folder drop to his start position.
4. See the file/folder was moved into the sub folder.

Steps to reproduce the behavior for bug 2:
1. Open a project and drag the first file/folder below the root folder.
2. Let the file/folder drop to his start position.
3. See the error in the browser console.

**Expected behavior**
The file/folder should not moved after drag and drop the file/folder to his start position. 
No error should appear after drag and drop the file/folder to his start position.

**Desktop (please complete the following information):**
 - OS: Linux
 - Browser: Firefox 147.0.4

**Additional info**
Tested with the latest changes from the development branch.

**This pull request**

1. Added and checks a `swapCount` to avoid the unintended file/folder move
2. Uses optional chaining to allow safely access `previousSibling` that could be null 