### PR TITLE
Logout compatibility change for the new batch-request system

### DIFF
--- a/components/user/controller.php
+++ b/components/user/controller.php
@@ -98,6 +98,7 @@ switch ($action) {
 		session_unset();
 		session_destroy();
 		session_start();
+		Common::send(204);
 		break;
 
 	//////////////////////////////////////////////////////////////////////////80


### PR DESCRIPTION
Thanks for the new batch-request system!

The logout  function needs a little change to work correctly with the new system.
Without sending a status from the [controller](https://github.com/Atheos/Atheos/blob/7719e95884387848bd6277bedafa43cef8c893e5/components/user/controller.php#L97-L101) after logout the reply was: `'{"status":200}'` and the processing ended at line 134 in /`libraries/echo.js` :
https://github.com/Atheos/Atheos/blob/7719e95884387848bd6277bedafa43cef8c893e5/libraries/echo.js#L130-L138
So logout is not working correctly because the `settled` function is not called in `postLogout`.

With sending a status after logout the reply was: ` '{"0":{"status":204,"data":{"status":204}},"status":200}'`
and the processing continued after line 134. 

The status code `204` was used because the `settled` function in `postLogout` does not await any reply messages.
https://github.com/Atheos/Atheos/blob/7719e95884387848bd6277bedafa43cef8c893e5/components/user/init.js#L351-L353