### PR TITLE
Makes available the already prepared functionality to display multiple diffs in codegit

### DIFF
--- a/components/codegit/init.js
+++ b/components/codegit/init.js
@@ -63,9 +63,11 @@
 				var target = oX(e.target);
 				if (target.tagName === 'BUTTON') {
 					if (target.attr('data-button') === 'diff') {
-						self.showPanel('diff', self.activeRepo, {
-							files: [target.parent('tr').attr('data-file')]
-						});
+						let data = {
+							files: self.getSelectedFiles(),
+							path: target.parent('tr').attr('data-file')
+						};
+						self.showPanel('diff', self.activeRepo, data);
 					} else if (target.attr('data-button') === 'undo') {
 						self.undo(self.activeRepo, target.parent('tr').attr('data-file'));
 					}
@@ -119,6 +121,18 @@
 				counter++;
 			}
 			return false;
+		},
+
+		getSelectedFiles: function() {
+			let selectedFiles = [],
+				checkboxes = oX('#codegit_overview tbody').findAll('input[type="checkbox"]');
+
+			checkboxes.forEach((checkbox) => {
+				if (checkbox.prop('checked')) {
+					selectedFiles.push(checkbox.parent('tr').attr('data-file'));
+				}
+			});
+			return selectedFiles;
 		},
 
 		//Check if directories has git repo
@@ -243,23 +257,16 @@
 		},
 
 		commit: function(amend) {
-			var message = oX('#commit_message');
-			var repo = self.activeRepo;
+			let message = oX('#commit_message');
+			let repo = self.activeRepo;
 
-			var data = {
+			let data = {
 				action: amend ? 'amend' : 'commit',
 				target: 'codegit',
-				files: [],
+				files: self.getSelectedFiles(),
 				message: message.value(),
 				repo
 			};
-
-			var checkboxes = oX('#codegit_overview tbody').findAll('input[type="checkbox"]');
-			checkboxes.forEach((checkbox) => {
-				if (checkbox.prop('checked')) {
-					data.files.push(checkbox.parent('tr').attr('data-file'));
-				}
-			});
 
 			echo({
 				url: atheos.controller,
@@ -269,6 +276,7 @@
 					if (status === 200) {
 						message.empty();
 						oX('input[type="checkbox"][group="cg_overview"][parent="true"').prop('checked', false);
+						let checkboxes = oX('#codegit_overview tbody').findAll('input[type="checkbox"]');
 						checkboxes.forEach((checkbox) => {
 							if (checkbox.prop('checked')) {
 								checkbox.parent('tr').remove();

--- a/components/codegit/templates/diff.php
+++ b/components/codegit/templates/diff.php
@@ -1,11 +1,8 @@
 <?php
 $files = POST("files");
 
-if ($files) {
-	$files = explode(",", $files);
-} else {
+if (empty($files)) {
 	$files = array($path);
-	echo "<label class=\"title\"><i class=\"fas fa-code-branch\"></i>" . i18n("codegit_diff") . "</label>";
 }
 
 $diffs = array();
@@ -13,6 +10,7 @@ foreach ($files as $i => $file) {
 	$diffs[] = $CodeGit->loadDiff($file);
 }
 
+echo "<label class=\"title\"><i class=\"fas fa-code-branch\"></i>" . i18n("codegit_diff") . "</label>";
 echo "<div id=\"codegit_diff\" class=\"content\">";
 
 foreach ($diffs as $i => $diff) {


### PR DESCRIPTION
This pull request makes available the already prepared functionality to display multiple diffs in codegit.
It also removes the unnecessary `explode()` function for the sent file paths in [`codegit/templates/diff.php`](https://github.com/Atheos/Atheos/blob/7719e95884387848bd6277bedafa43cef8c893e5/components/codegit/templates/diff.php#L5) to fix codgit diff not opened with the new batch-request system. The sent files paths are now already wrapped in an array. 

Without the compatibility fix opening a diff view ends up in a sever error:

```
XHRPOST
https://myAtheos/dialog.php
[HTTP/2 500  278ms]

	
action	"loadPanel"
files   ["path/to/file1"]
panel	"diff"
repo	"/path/to/my/repo"
target	"codegit"
```