### PR TITLE
Settings compatibility change for the new batch-request system.

### DIFF
--- a/components/settings/controller.php
+++ b/components/settings/controller.php
@@ -30,7 +30,7 @@ switch ($action) {
 	case "save":
 		$key = POST("key");
 		$value = POST("value");
-		if ($key && $value) {
+		if ($key && isset($value)) {
 			$Settings->save($key, $value);
 		} else {
 			Common::send(417, "Missing key or value.");


### PR DESCRIPTION
**Describe the bug**
It is not possible to disable toggle options in the settings dialog after the changes for the [new batch-request system](https://github.com/Atheos/Atheos/commit/17707ca63954a963ca26f7457eeea4c638e23180).

**To Reproduce**
Steps to reproduce the behavior:
1. Open the settings dialog and select "Editor Style".
2. Disable the toggle option "Show Invisibles".
3. See the error message "Missing key or value." as a toast notifications.

**Expected behavior**
The settings toggle option should be saved.

**Desktop (please complete the following information):**
 - OS: Linux
 - Browser: Firefox 147.0.4

**Reason**
The settings controller save method ignores values with `false` because they are now boolean values and not string values.

**Additional info**
Tested with the latest changes from the development branch.

**This pull request**
Replaced truthy check for `$value ` in the controller save method with the `isset() `method to show an error only if  `$value` is `null`.