### PR TITLE
Resolves #339 postLogout is called before all files saved to server

### DIFF
--- a/components/editor/init.js
+++ b/components/editor/init.js
@@ -649,7 +649,11 @@
 				if (file.fileTab) {
 					file.fileTab.removeClass('changed');
 				}
-				carbon.publish('session.saved', file.path);
+				carbon.publish('editor.saved', file.path);
+
+				if (self.getChangedPaths().length === 0) {
+					carbon.publish('editor.allSaved');
+				}
 			};
 
 			// HLSiira: I'm uncertain why this If statement is here.

--- a/components/user/init.js
+++ b/components/user/init.js
@@ -368,7 +368,9 @@
 					actions: {
 						'Save All & Close': function() {
 							atheos.editor.saveAll();
-							postLogout();
+							carbon.subscribe('editor.allSaved', function() {
+								postLogout();
+							});
 						},
 						'Discard Changes': function() {
 							changedPaths.forEach(function(path) {


### PR DESCRIPTION
This pull request resolves #339.
Also the context for the published save status of a file was corrected to `editor`.