### PR TITLE
Empties the paneTree storage value and thus prevents the creation of a buggy editor pane

### DIFF
--- a/components/editor/init.js
+++ b/components/editor/init.js
@@ -354,7 +354,7 @@
 		},
 
 		//////////////////////////////////////////////////////////////////////80
-		// Remove all Editor instances and clean up the DOM
+		// Remove all Editor instances, clean up the DOM and the storage
 		//////////////////////////////////////////////////////////////////////80
 		exterminate: function() {
 			for (var i = self.editorPanes.length - 1; i >= 0; i--) {
@@ -368,6 +368,7 @@
 			inFocus.aceEditor = null;
 			oX('#current_file').html('');
 			oX('#current_mode>span').html('');
+			storage('editor.paneTree', '');
 		},
 
 		/////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Describe the bug**
With the latest changes from the development branch a buggy editor pane was created after closing all files and a reload of the page. The pane has no tab and after clicking in the editor this error appears in the browser console:

```js
Uncaught TypeError: can't access property "fileTab", file is undefined
    highlightEntry https://myAtheos/modules/filetab.js:281
    syncSystemFocus https://myAtheos/components/editor/init.js:383
    createEditorPane https://myAtheos/components/editor/init.js:166
    _dispatchEvent https://myAtheos/components/editor/ace-editor/ace.js:1
    onFocus https://myAtheos/components/editor/ace-editor/ace.js:1
    e https://myAtheos/components/editor/ace-editor/ace.js:1
    addListener https://myAtheos/components/editor/ace-editor/ace.js:1
    e https://myAtheos/components/editor/ace-editor/ace.js:1
    e https://myAtheos/components/editor/ace-editor/ace.js:1
    createEditorPane https://myAtheos/components/editor/init.js:156
    restorePaneTree https://myAtheos/components/editor/init.js:221
    openFiles https://myAtheos/components/editor/init.js:436
    promise callback*openFiles https://myAtheos/components/editor/init.js:435
    settled https://myAtheos/modules/system.js:107
    processReply https://myAtheos/libraries/echo.js:50
    settled https://myAtheos/libraries/echo.js:137
    settled https://myAtheos/libraries/echo.js:132
    processReply https://myAtheos/libraries/echo.js:50
    onreadystatechange https://myAtheos/libraries/echo.js:92
    sendRequest https://myAtheos/libraries/echo.js:88
    sendQueue https://myAtheos/libraries/echo.js:123
    setTimeout handler*echo https://myAtheos/libraries/echo.js:159
    restoreState https://myAtheos/modules/system.js:84
    init https://myAtheos/modules/system.js:52
    EventListener.handleEvent* https://myAtheos/modules/system.js:117
    <anonymous> https://myAtheos/modules/system.js:119
```

**Screenshot**
![buggy-editor-pane](https://github.com/user-attachments/assets/3a91027c-b13a-48d5-8cda-4347e541f305)


**To Reproduce**
Steps to reproduce the behavior:

 1. Open at least one file.
 2. Close all files and reload the page.
 3. See the buggy pane without a tab was created.

**Expected behavior**
After closing all files and a page reload no pane should be created.

**Desktop (please complete the following information):**

 - OS: Linux
 - Browser: Firefox 147.0.3

**This pull request**
Empties the paneTree storage value in the `exterminate` method to avoid the creation of the buggy editor pane.