### PR TITLE
Allows the user to set a custom system theme regardless of the THEME constant in the config.php file.

### DIFF
--- a/components/settings/init.js
+++ b/components/settings/init.js
@@ -101,6 +101,25 @@
 			} else if (setting.startsWith('editor.')) {
 				let option = setting.replace('editor.', '');
 				atheos.editor.setOption(option, value);
+
+				if (option == 'theme') {
+					let themeName = value.split('/').pop();
+					let themePromise = new Promise(resolve =>
+						atheos.common.loadScript(
+							'components/editor/ace-editor/theme-' + themeName + '.js',
+							resolve
+						)
+					);
+
+					// Set system theme based on isDark value of ace-editor theme
+					themePromise.then(function() {
+						let themeModule = ace.require(value),
+							mode = themeModule.isDark ? "dark " : "light ",
+							color = document.documentElement.classList[1];
+						self.save("system.theme", mode + color, true);
+					});
+				}
+
 			} else {
 				switch (setting) {
 					case 'editor.loopBehavior':
@@ -129,6 +148,9 @@
 						break;
 					case 'output.location':
 						atheos.output.setLocation(value);
+						break;
+					case 'system.theme':
+						document.documentElement.className = value;
 						break;
 				}
 			}

--- a/components/settings/panels/system.php
+++ b/components/settings/panels/system.php
@@ -1,6 +1,19 @@
 <label><i class="fas fa-sliders-h"></i><?php echo i18n("settings_system"); ?></label>
 <table>
 	<tr>
+		<td><?php echo i18n("theme"); ?></td>
+		<td>
+			<select class="setting" data-setting="system.theme">
+				<option value="dark blue" default selected><?php echo i18n("theme_dark_blue"); ?></option>
+				<option value="dark red"><?php echo i18n("theme_dark_red"); ?></option>
+				<option value="dark green"><?php echo i18n("theme_dark_green"); ?></option>
+				<option value="light blue"><?php echo i18n("theme_light_blue"); ?></option>
+				<option value="light red"><?php echo i18n("theme_light_red"); ?></option>
+				<option value="light green"><?php echo i18n("theme_light_green"); ?></option>
+			</select>
+		</td>
+	</tr>
+	<tr>
 		<td><?php echo i18n("loop_behavior"); ?></td>
 		<td>
 			<toggle>

--- a/index.php
+++ b/index.php
@@ -21,9 +21,18 @@ if (defined("HEADERS") && HEADERS) {
 require_once("classes/sourcemanager.php");
 $SourceManager = new SourceManager;
 
+if (defined("THEME") && THEME) $theme = THEME;
+
+// Try to get the system theme from the user settings
+$activeUser = SESSION("user");
+if ($activeUser) {
+	$userTheme = Common::getKeyStore("settings", "users/" . $activeUser)->select("system.theme");
+	if ($userTheme) $theme = $userTheme;
+}
+
 ?>
 <!doctype html>
-<html lang="en" class="<?php if (defined("THEME") && THEME) echo(THEME) ?>">
+<html lang="en" class="<?php if (isset($theme) && $theme) echo($theme) ?>">
 <head>
     <meta charset="utf-8">
     <title><?php if (defined("TITLE") && TITLE) echo(TITLE . " | ") ?>Atheos IDE</title>

--- a/languages/en.json
+++ b/languages/en.json
@@ -434,7 +434,20 @@
 	"printMarginShow": "Print Margin",
 	"printMarginColumn": "Print Margin Column",
 
-	"theme": "Theme",
+	"theme": {
+		"": "Theme",
+		"dark": {
+			"blue": "Dark blue",
+			"red": "Dark red",
+			"green": "Dark green"
+		},
+		"light": {
+			"blue": "Light blue",
+			"red": "Light red",
+			"green": "Light green"
+		}
+	},
+
 	"hover": {
 		"": "Hover",
 		"duration": "Sidebar Hover Duration"


### PR DESCRIPTION
Switching to a light ace-editor theme in the user settings does not change the system theme. 
The result looks like this:

![light-ace-editor-theme](https://github.com/user-attachments/assets/2d7671ad-b783-43b2-bcdc-3c026fb1ddd1)

The user might assume it's a bug if they don't know about the THEME option in the config.php file.
Also setting the THEME constant in the config.php is for all users and does not allow an individual system theme per user.

This pull request solves this problem and allows to set each user his preferred system theme.
In addition, the system theme is automatically adjusted based on the isDark value from the selected ace-editor theme.

Switching to a light ace-editor theme automatically looks like this:

![light-ace-editor-theme-and-light -system-theme](https://github.com/user-attachments/assets/662d950a-0113-466c-bd39-60e96fbdff1d)



