### PR TITLE
Fix wrong default textmodes are selected in settings and undefined textmode save message

### DIFF
--- a/components/settings/panels/textmode.php
+++ b/components/settings/panels/textmode.php
@@ -42,7 +42,7 @@ if (!$map || !is_array($map)) {
 			} ?>
 			<tr>
 				<td><input type="text" name="extension" value="<?php echo $extension ?>" /></td>
-				<td><?php echo $TextMode->createTextModeSelect($extension) ?></td>
+				<td><?php echo $TextMode->createTextModeSelect($extension, $mode) ?></td>
 			</tr>
 			<?php
 		}

--- a/components/textmode/class.textmode.php
+++ b/components/textmode/class.textmode.php
@@ -273,13 +273,13 @@ class TextMode {
 	//////////////////////////////////////////////////////////////////
 	// Create a select field with options for all availble textmodes, current one selected.
 	//////////////////////////////////////////////////////////////////
-	public function createTextModeSelect($extension) {
+	public function createTextModeSelect($extension, $currentMode) {
 		$extension = trim(strtolower($extension));
 		$find = false;
 		$html = '<select name="textmode">'."\n";
 		foreach ($this->availableModes as $mode) {
 			$html .= '	<option';
-			if ($mode == $extension) {
+			if ($mode == $currentMode) {
 				$html .= ' selected="selected"';
 				$find = true;
 			}

--- a/components/textmode/init.js
+++ b/components/textmode/init.js
@@ -192,7 +192,7 @@
 				url: atheos.controller,
 				data: data,
 				settled: function(reply, status) {
-					toast(status, reply.message);
+					toast(status, reply.text);
 
 					if (status === 200 && reply.extensions) {
 						self.setEditorTextModes(reply);


### PR DESCRIPTION
**Describe the bug**
The default textmodes not showing the correct mode in settings panel. This causes overrides with wrong modes when saving after adding a new textmode. 

Also after saving the textmodes, `Message undefined` is displayed.

**Screenshot**
<img width="797" height="551" alt="textmodes_1" src="https://github.com/user-attachments/assets/2720c494-d9dd-41da-b402-9ea5ee939443" />


**To Reproduce**
Steps to reproduce the behavior:

 1. Open textmode panel in settings.
 2. See the extension  `c` with the wrong mode `yaml` in the select input.

The mapping is wrong for all selects where the extension is not matching the mode.

**Expected behavior**
The select inputs should show the correct mode for the extension.

**Desktop (please complete the following information):**

 - OS: Linux
 - Browser: Firefox 150.0

**This pull request**
Resolves the mapping issue with an additional parameter for the current mode.
Also switched to the correct property `text` for the `reply` object to get the correct save message.